### PR TITLE
CB-Dragonfly 설정파일 수정 적용 

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -2,7 +2,9 @@
 
 # influxdb connection info
 influxdb:
-  endpoint_url: http://cb-dragonfly-influxdb:8086 # endpoint for influxDB
+  endpoint_url: http://cb-draonfly-influxdb # endpoint for influxDB
+  internal_port: 8086
+  external_port: 28086
   database: cbmon
   userName: cbmon
   password: password

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,8 +42,8 @@ services:
     image: influxdb:1.8-alpine
     container_name: cb-dragonfly-influxdb
     ports:
-      - 8083:8083
-      - 8086:8086
+      - 28083:8083
+      - 28086:8086
     environment:
       - PRE_CREATE_DB=cbmon
       - INFLUXDB_DB=cbmon

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,10 +18,12 @@ type Config struct {
 }
 
 type InfluxDB struct {
-	EndpointUrl string `json:"endpoint_url" mapstructure:"endpoint_url"`
-	Database    string
-	UserName    string
-	Password    string
+	EndpointUrl  string `json:"endpoint_url" mapstructure:"endpoint_url"`
+	InternalPort int    `json:"internal_port" mapstructure:"internal_port"`
+	ExternalPort int    `json:"external_port" mapstructure:"external_port"`
+	Database     string
+	UserName     string
+	Password     string
 }
 
 type Etcd struct {

--- a/pkg/core/agent/agent.go
+++ b/pkg/core/agent/agent.go
@@ -172,7 +172,7 @@ func cleanTelegrafInstall(sshInfo sshrun.SSHInfo, osType string) {
 
 func createTelegrafConfigFile(nsId string, mcisId string, vmId string, cspType string) (string, error) {
 	collectorServer := fmt.Sprintf("udp://%s:%d", config.GetInstance().CollectManager.CollectorIP, config.GetInstance().CollectManager.CollectorPort)
-	influxDBServer := fmt.Sprintf("http://%s:8086", config.GetInstance().CollectManager.CollectorIP)
+	influxDBServer := fmt.Sprintf("%s:%d", config.GetInstance().InfluxDB.EndpointUrl, config.GetInstance().InfluxDB.ExternalPort)
 	userName := fmt.Sprintf(config.GetInstance().InfluxDB.UserName)
 	password := fmt.Sprintf(config.GetInstance().InfluxDB.Password)
 	rootPath := os.Getenv("CBMON_ROOT")

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -45,7 +45,7 @@ func NewCollectorManager() (*CollectManager, error) {
 	influxConfig := influxdbv1.Config{
 		ClientOptions: []influxdbv1.ClientOptions{
 			{
-				URL:      config.GetInstance().GetInfluxDBConfig().EndpointUrl,
+				URL:      fmt.Sprintf("%s:%d", config.GetInstance().GetInfluxDBConfig().EndpointUrl, config.GetInstance().GetInfluxDBConfig().ExternalPort),
 				Username: config.GetInstance().GetInfluxDBConfig().UserName,
 				Password: config.GetInstance().GetInfluxDBConfig().Password,
 			},


### PR DESCRIPTION
- 설정 파일 config.yaml 변경
  * Telegraf <-> Influxdb 통신을 위한 External Port 명시
  * CB-Dragonfly <-> Influxdb 통신을 위한 External Port 명시
- Collector Manager, Telegraf url 설정 자동 입력 기능 추가
- docker-compose yaml 파일 최신화
  * influxdb 외부 포트 변경 8086:8086 -> 28086:8086