### PR TITLE
[CB-Dragonfly] 메타데이터 생성/삭제 추가

### DIFF
--- a/pkg/localstore/cbstore.go
+++ b/pkg/localstore/cbstore.go
@@ -1,0 +1,77 @@
+package localstore
+
+import (
+	cb "github.com/cloud-barista/cb-store"
+	icbs "github.com/cloud-barista/cb-store/interfaces"
+	"sync"
+	//	"github.com/cloud-barista/cb-store/utils"
+	"github.com/sirupsen/logrus"
+)
+
+type CBStore struct {
+	Store icbs.Store
+}
+
+var once sync.Once
+var cbstore CBStore
+
+func Initialize() {
+	cbstore.Store = cb.GetStore()
+}
+
+func GetInstance() *CBStore {
+	once.Do(func() {
+		Initialize()
+	})
+	return &cbstore
+}
+
+func (cs *CBStore) StorePut(key string, value string) error {
+	return cs.Store.Put(key, value)
+}
+
+func (cs *CBStore) StoreGet(key string) string {
+	keyVal, err := cs.Store.Get(key)
+	if err != nil {
+		logrus.Debug(err)
+		return err.Error()
+	}
+	return keyVal.Value
+}
+
+func (cs *CBStore) StoreDelete(key string) error {
+	return cs.Store.Delete(key)
+}
+
+func (cs *CBStore) StoreGetList(key string, sortAscend bool) []string {
+	keyVal, err := cs.Store.GetList(key, sortAscend)
+	if err != nil {
+		logrus.Debug(err)
+		return []string{err.Error()}
+	}
+	result := make([]string, len(keyVal))
+	for _, ev := range keyVal {
+		result = append(result, ev.Key)
+	}
+	return result
+}
+
+func (cs *CBStore) StoreDelList(key string) error {
+	keyVal, err := cs.Store.GetList(key, true)
+	if err != nil {
+		logrus.Debug(err)
+		return err
+	}
+	for _, ev := range keyVal {
+		err = cs.Store.Delete(ev.Key)
+		return err
+	}
+	return nil
+}
+
+/*
+func (cs *CBStore) StoreGetNodeValue(key string, depth int) string {
+	return utils.GetNodeValue(key, depth) 기능 개선
+}
+
+*/

--- a/pkg/localstore/metadata.go
+++ b/pkg/localstore/metadata.go
@@ -1,0 +1,105 @@
+package localstore
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/cloud-barista/cb-dragonfly/pkg/api/rest"
+	"github.com/labstack/echo/v4"
+	"net/http"
+)
+
+const (
+	ENABLE  = "Enable"
+	DISABLE = "Disable"
+)
+
+type Metadata struct {
+	Key   *string
+	Value *AgentInfo
+}
+
+type AgentInfo struct {
+	AgentState *string
+	AgentType  *string
+	Public_IP  *string
+}
+
+var metadata = &Metadata{}
+var agentinfo = &AgentInfo{}
+
+func setAgentInfo(agentstate *string, agenttype *string, public_ip *string) {
+	getAgentInfo().AgentState = agentstate
+	getAgentInfo().AgentType = agenttype
+	getAgentInfo().Public_IP = public_ip
+}
+func getAgentInfo() *AgentInfo {
+	return agentinfo
+}
+func setMetadata(uuid *string, agentinfo *AgentInfo) {
+	getMetadata().Key = uuid
+	getMetadata().Value = agentinfo
+}
+
+func getMetadata() *Metadata {
+	return metadata
+}
+
+func AgentInstallationMetadata(nsId string, mcisId string, vmId string, cspType string, publicIp string) error {
+	agent_State := ENABLE
+	agent_Type := ENABLE
+	setAgentInfo(&agent_State, &agent_Type, &publicIp)
+	setMetadata(makeAgentUUID(nsId, mcisId, vmId, cspType), getAgentInfo())
+	data, err := json.Marshal(getMetadata().Value)
+	if err != nil {
+		return errors.New(fmt.Sprintf("failed to convert metadata format to json, error=%s", err))
+	}
+
+	err = GetInstance().StorePut(*getMetadata().Key, string(data))
+	if err != nil {
+		return errors.New(fmt.Sprintf("failed to put metadata, error=%s", err))
+	}
+	return nil
+}
+
+func AgentDeletionMetadata(nsId string, mcisId string, vmId string, cspType string, publicIp string) error {
+	agent_State := DISABLE
+	agent_Type := DISABLE
+	setAgentInfo(&agent_State, &agent_Type, &publicIp)
+	setMetadata(makeAgentUUID(nsId, mcisId, vmId, cspType), getAgentInfo())
+
+	_, err := json.Marshal(getMetadata().Value)
+	if err != nil {
+		return errors.New(fmt.Sprintf("failed to convert metadata format to json, error=%s", err))
+	}
+
+	err = GetInstance().StoreDelete(*getMetadata().Key)
+	if err != nil {
+		return errors.New(fmt.Sprintf("failed to delete metadata, error=%s", err))
+	}
+	return nil
+}
+
+func makeAgentUUID(nsId string, mcisId string, vmId string, cspType string) *string {
+	data := fmt.Sprintf(nsId + "/" + mcisId + "/" + vmId + "/" + cspType)
+	return &data
+}
+
+func ShowMetadata(c echo.Context) error {
+	//온디멘드 모니터링 Agent IP 파라미터 추출
+	ns_id := c.Param("ns")
+	mcis_id := c.Param("mcis_id")
+	vm_id := c.Param("vm_id")
+	csp_type := c.Param("csp_type")
+
+	// Query 파라미터  값 체크
+	if ns_id == "" || mcis_id == "" || vm_id == "" || csp_type == "" {
+		return c.JSON(http.StatusInternalServerError, rest.SetMessage("failed to get package. query parameter is missing"))
+	}
+	value, err := GetInstance().Store.Get(fmt.Sprintf(ns_id + "/" + mcis_id + "/" + vm_id + "/" + csp_type))
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, errors.New(fmt.Sprintf("Get Data from CB-Store Error, err=%s", err)))
+	}
+
+	return c.JSON(http.StatusOK, value)
+}

--- a/pkg/manager/apiserver.go
+++ b/pkg/manager/apiserver.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"fmt"
+	"github.com/cloud-barista/cb-dragonfly/pkg/localstore"
 	"net/http"
 	"sync"
 
@@ -96,5 +97,8 @@ func (apiServer *APIServer) SetRoutingRule(e *echo.Echo) {
 	// 알람 이벤트 로그 조회, 생성
 	dragonfly.POST("/alert/event", alert.CreateEventLog)
 	dragonfly.GET("/alert/task/:task_id/events", alert.ListEventLog)
+
+	// 메타데이터 관리 테스트용 API
+	dragonfly.GET("/metadata/ns/:ns/mcis/:mcis_id/vm/:vm_id/csp/:csp_type", localstore.ShowMetadata)
 
 }


### PR DESCRIPTION
- CB-Store 추가 [ Kafka 브랜치 내용 일부 포함 localstore/cbstore.go]
- Install / Uninstall 시 CB-Store에 저장 및 삭제 기능 추가
- 메타데이터 확인을 위한 시험용 API 추가