### PR TITLE
[CB-Dragonfly] 에스프레소 버전 수정 적용 (11.5 기준)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,8 @@ COPY --from=go-builder ${GOPATH}/src/github.com/cloud-barista/cb-dragonfly/bin/c
 RUN chmod +x /opt/cb-dragonfly/bin/cb-dragonfly \
     && ln -s /opt/cb-dragonfly/bin/cb-dragonfly /usr/bin
 
-EXPOSE 8094/udp
+#EXPOSE 8094/udp
 EXPOSE 9090
+EXPOSE 9999
 
 ENTRYPOINT ["cb-dragonfly"]

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -14,6 +14,8 @@ kapacitor:
 
 kafka:
   endpoint_url: cb-dragonfly-kafka
+  external_ip: 210.207.104.136
+  external_port: 32000
 
 # collect manager configuration info
 collectManager:

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -14,7 +14,7 @@ kapacitor:
 
 kafka:
   endpoint_url: cb-dragonfly-kafka
-  external_ip: 210.207.104.136
+  external_ip: 127.0.0.1
   external_port: 32000
 
 # collect manager configuration info

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -14,8 +14,9 @@ kapacitor:
 
 kafka:
   endpoint_url: cb-dragonfly-kafka
-  external_ip: 210.207.104.136
+  external_ip: 127.0.0.1
   external_port: 32000
+  internal_port: 9092
 
 # collect manager configuration info
 collectManager:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,13 +6,14 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: cloudbaristaorg/cb-dragonfly:espresso-v0.1-inno-test
+    image: cloudbaristaorg/cb-dragonfly:espresso-v0.1-kafka
     container_name: cb-dragonfly
     volumes:
       - ./conf:/go/src/github.com/cloud-barista/cb-dragonfly/conf
       - ./log:/go/src/github.com/cloud-barista/cb-dragonfly/log
     ports:
       - 9090:9090
+      - 9999:9999
     depends_on:
       - cb-dragonfly-zookeeper
       - cb-dragonfly-kafka

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ type Kafka struct {
 	EndpointUrl  string `json:"endpoint_url" mapstructure:"endpoint_url"`
 	ExternalIP   string `json:"external_ip" mapstructure:"external_ip"`
 	ExternalPort int    `json:"external_port" mapstructure:"external_port"`
+	InternalPort int    `json:"internal_port" mapstructure:"internal_port"`
 }
 
 type InfluxDB struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,7 +23,9 @@ type Kapacitor struct {
 }
 
 type Kafka struct {
-	EndpointUrl string `json:"endpoint_url" mapstructure:"endpoint_url"`
+	EndpointUrl  string `json:"endpoint_url" mapstructure:"endpoint_url"`
+	ExternalIP   string `json:"external_ip" mapstructure:"external_ip"`
+	ExternalPort int    `json:"external_port" mapstructure:"external_port"`
 }
 
 type InfluxDB struct {

--- a/pkg/core/agent/agent.go
+++ b/pkg/core/agent/agent.go
@@ -112,7 +112,7 @@ func InstallTelegraf(nsId string, mcisId string, vmId string, publicIp string, u
 	}
 
 	// 카프카 도메인 정보 기입 /etc/hosts => agent에서 도메인 등록하도록 기능 변경
-	inputKafkaServerDomain := fmt.Sprintf("echo '%s %s' | sudo tee -a /etc/hosts", config.GetInstance().CollectManager.CollectorIP, "cb-dragonfly-kafka")
+	inputKafkaServerDomain := fmt.Sprintf("echo '%s %s' | sudo tee -a /etc/hosts", config.GetInstance().GetKafkaConfig().ExternalIP, "cb-dragonfly-kafka")
 	_, err = sshrun.SSHRun(sshInfo, inputKafkaServerDomain)
 	if err != nil {
 		cleanTelegrafInstall(sshInfo, osType)
@@ -212,7 +212,7 @@ func createTelegrafConfigFile(nsId string, mcisId string, vmId string, cspType s
 	strConf = strings.ReplaceAll(strConf, "{{csp_type}}", cspType)
 
 	strConf = strings.ReplaceAll(strConf, "{{topic}}", fmt.Sprintf("%s_%s_%s_%s", nsId, mcisId, vmId, cspType))
-	strConf = strings.ReplaceAll(strConf, "{{broker_server}}", fmt.Sprintf("%s:%s", config.GetDefaultConfig().GetKafkaConfig().GetKafkaEndpointUrl(), "9092"))
+	strConf = strings.ReplaceAll(strConf, "{{broker_server}}", fmt.Sprintf("%s:%d", config.GetInstance().GetKafkaConfig().GetKafkaEndpointUrl(), config.GetInstance().GetKafkaConfig().ExternalPort))
 	// telegraf.conf 파일 생성
 	telegrafFilePath := rootPath + "/file/conf/"
 	createFileName := "telegraf-" + uuid.New().String() + ".conf"
@@ -316,7 +316,7 @@ func UninstallAgent(
 	}
 	// sudo perl -pi -e "s,^192.168.130.14.*tml\n$,," /etc/hosts
 
-	Cmd = fmt.Sprintf("sudo perl -pi -e 's,^%s.*%s\n$,,' /etc/hosts", config.GetInstance().CollectManager.CollectorIP, "cb-dragonfly-kafka")
+	Cmd = fmt.Sprintf("sudo perl -pi -e 's,^%s.*%s\n$,,' /etc/hosts", config.GetInstance().GetKafkaConfig().ExternalIP, "cb-dragonfly-kafka")
 	if _, err := sshrun.SSHRun(sshInfo, Cmd); err != nil {
 		cleanTelegrafInstall(sshInfo, osType)
 		return http.StatusInternalServerError, errors.New(fmt.Sprintf("failed to delete domain list, error=%s", err))

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -49,7 +49,7 @@ func NewCollectorManager() (*CollectManager, error) {
 	}
 
 	timeout := time.Duration(1 * time.Second)
-	_, err = net.DialTimeout("tcp", fmt.Sprintf("%s:%s", config.GetInstance().GetKafkaConfig().GetKafkaEndpointUrl(), config.GetInstance().GetKafkaConfig().ExternalPort), timeout)
+	_, err = net.DialTimeout("tcp", fmt.Sprintf("%s:%d", config.GetInstance().GetKafkaConfig().GetKafkaEndpointUrl(), config.GetInstance().GetKafkaConfig().InternalPort), timeout)
 	if err != nil {
 		fmt.Printf("%s %s \n", "kafka is not responding", err.Error())
 		logrus.Error(err)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -49,7 +49,7 @@ func NewCollectorManager() (*CollectManager, error) {
 	}
 
 	timeout := time.Duration(1 * time.Second)
-	_, err = net.DialTimeout("tcp", fmt.Sprintf("%s", config.GetDefaultConfig().GetKafkaConfig().GetKafkaEndpointUrl())+":32000", timeout)
+	_, err = net.DialTimeout("tcp", fmt.Sprintf("%s:%s", config.GetInstance().GetKafkaConfig().GetKafkaEndpointUrl(), config.GetInstance().GetKafkaConfig().ExternalPort), timeout)
 	if err != nil {
 		fmt.Printf("%s %s \n", "kafka is not responding", err.Error())
 		logrus.Error(err)


### PR DESCRIPTION
1. Config.yaml 수정
    * Kafka 외부 IP/Port , 내부 Port 추가
    * IP 일반화
2. Dockerfile 수정
    * GRPC 포트 추가
    * UDP 포트 주석
3. Docker-compose Yaml 수정
    * GRPC 포트 추가
4. Manager.go 수정
    * Kafka Config yaml 내용 적용 기능 개선
5. core/agent 수정
    * Agent 설정 파일 (Telegraf.conf) Kafka URL, Port 적용 기능 추가
    * Agent /etc/hosts 삭제 기능 개선